### PR TITLE
Fix: Configure Gemini API key for Vite

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2168,7 +2168,7 @@ const ActionButton = ({ onGenerateGoals, onGenerateFeatures, onShowVoiceModal, i
 const GeminiWrapper = ({ children, tasks, onNewGoals, onNewFeatures, onAddTask, onCompleteTask }) => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const ai = useMemo(() => new GoogleGenAI({ apiKey: process.env.API_KEY as string }), []);
+    const ai = useMemo(() => new GoogleGenAI({ apiKey: import.meta.env.VITE_GEMINI_API_KEY as string }), []);
 
     const callGemini = async (prompt: string, schema?: any) => {
         setIsLoading(true);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,12 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
-    return {
-      plugins: [react()],
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
-      resolve: {
-        alias: {
-          '@': path.resolve(__dirname, '.'),
-        }
-      }
-    };
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    }
+  }
 });


### PR DESCRIPTION
- Updated `index.tsx` to use `import.meta.env.VITE_GEMINI_API_KEY` to access the Gemini API key, following Vite's standard for environment variables.
- Removed the custom `define` block from `vite.config.ts` as it is no longer necessary and was causing build failures.