### PR TITLE
fix: Prevent blank screen when Gemini API key is missing

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2168,9 +2168,20 @@ const ActionButton = ({ onGenerateGoals, onGenerateFeatures, onShowVoiceModal, i
 const GeminiWrapper = ({ children, tasks, onNewGoals, onNewFeatures, onAddTask, onCompleteTask }) => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const ai = useMemo(() => new GoogleGenAI({ apiKey: import.meta.env.VITE_GEMINI_API_KEY as string }), []);
+    const ai = useMemo(() => {
+        const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+        if (!apiKey) {
+            console.warn("Chave da API do Gemini não encontrada. Funções de IA estarão desabilitadas.");
+            return null;
+        }
+        return new GoogleGenAI({ apiKey: apiKey as string });
+    }, []);
 
     const callGemini = async (prompt: string, schema?: any) => {
+        if (!ai) {
+            setError("A chave da API de IA não está configurada. Por favor, adicione VITE_GEMINI_API_KEY ao seu ambiente.");
+            return null;
+        }
         setIsLoading(true);
         setError(null);
         try {


### PR DESCRIPTION
The application would crash with a blank white screen if the VITE_GEMINI_API_KEY environment variable was not set. This was because the `GoogleGenAI` client was being initialized without a valid API key, causing an unhandled exception.

This change introduces a check to ensure the API key exists before initializing the Gemini client. If the key is not found, the AI-related features are gracefully disabled, and a warning is logged to the console.

Additionally, if a user attempts to use an AI feature without a configured API key, a user-friendly error message is now displayed in the UI.